### PR TITLE
Frama c 31 upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - "4.13.1"
-          - "5.1"
+          - "4.14.2"
 
     runs-on: ${{ matrix.os }}
 
@@ -32,6 +31,8 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: |
-          opam install . --deps-only --with-test
-          opam exec -- dune build
-          opam exec -- dune runtest
+          opam --cli=2.1 install . --deps-only --with-test
+          opam --cli=2.1 exec -- frama-c-ptests
+          opam --cli=2.1 exec -- dune build @install
+          opam --cli=2.1 exec -- dune build @ptests
+          opam --cli=2.1 exec -- dune runtest

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
   (name frama-c-isp)
  (depends
   (ocaml (>= 4.14.2))
-  (frama-c (= 31)))
+  (frama-c (= 31.0)))
  (synopsis "Automatic inference of ACSL auxilliary annotations")
  (description "This plugin for the Frama-C platform for source code analysis
 of C programs provides automatic inference of ACSL auxilliary annotations."))

--- a/dune-project
+++ b/dune-project
@@ -14,8 +14,8 @@
 (package 
   (name frama-c-isp)
  (depends
-  (ocaml (>= 4.13.1))
-  (frama-c (>= 29)))
+  (ocaml (>= 4.14.2))
+  (frama-c (= 31)))
  (synopsis "Automatic inference of ACSL auxilliary annotations")
  (description "This plugin for the Frama-C platform for source code analysis
 of C programs provides automatic inference of ACSL auxilliary annotations."))

--- a/frama-c-isp.opam
+++ b/frama-c-isp.opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/rse-verification/isp/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.14.2"}
-  "frama-c" {= "31"}
+  "frama-c" {= "31.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/frama-c-isp.opam
+++ b/frama-c-isp.opam
@@ -13,8 +13,8 @@ homepage:
 bug-reports: "https://github.com/rse-verification/isp/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.13.1"}
-  "frama-c" {>= "29"}
+  "ocaml" {>= "4.14.2"}
+  "frama-c" {= "31"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/isp_emitters.ml
+++ b/src/isp_emitters.ml
@@ -277,13 +277,14 @@ module Auxiliary = struct
       contract of the given function. 'to_term' is a function that converts
       an lval into a term. *)
   let emit_lval_spec spec_type lvalue to_term req new_kf filling_actions =
-    match Cil.unrollType (Cil.typeOfLval lvalue) with
+    let unrolled_typ = (Ast_types.unroll (Cil.typeOfLval lvalue)) in
+    match unrolled_typ.tnode with
     | TNamed _ -> 
       (* TODO: May be the case with TPtr TArray etc. Check Cil.unrollTypeDeep. *)
       failwith "Trying to emit annotations for non-unrolled type."
-    | TComp _ as styp->
+    | TComp _ ->
         let (lhost, _) = lvalue in
-        let offsets = Isp_utils.find_field_offsets styp in
+        let offsets = Isp_utils.find_field_offsets unrolled_typ in
         p_debug "···· number of found offsets %i" (List.length offsets) ~level:4;
         List.iter 
           (fun offset ->

--- a/src/isp_utils.ml
+++ b/src/isp_utils.ml
@@ -190,11 +190,11 @@ let get_lvals_with_const_index (lh, o) req =
 
 
 let rec find_field_offsets typ =
-  match Cil.unrollType typ with
+  match (Ast_types.unroll typ).tnode with
   | TNamed _ -> 
     (* TODO: May be the case with TPtr TArray etc. Check Cil.unrollTypeDeep. *)
     failwith "Trying to emit annotations for non-unrolled type."
-  | TComp (compinfo, _) ->
+  | TComp (compinfo) ->
       List.flatten 
         (List.map
           (fun fieldinfo ->

--- a/src/isp_visitor.ml
+++ b/src/isp_visitor.ml
@@ -94,7 +94,7 @@ class interface_specifications_propagator _ep prj =
             p_debug "· Adding arguments to Visited_function_arguments.";
             List.iter
               (fun vi ->
-                match unrollType vi.vtype with
+                match (Ast_types.unroll vi.vtype).tnode with
                 | TPtr _ ->
                     Isp_local_states.Visited_function_arguments.add_ptr_arg
                       vi.vid;
@@ -200,8 +200,8 @@ class interface_specifications_propagator _ep prj =
                     match lv with
                     | Var vi, _o -> (
                         p_debug "· The Lval is of type Var.";
-                        match vi.vtype with
-                        | TFun (_, _, _, _) ->
+                        match vi.vtype.tnode with
+                        | TFun (_, _, _) ->
                             p_debug "· The Var is a function.";
                             let kf = Globals.Functions.find_by_name vi.vname in
                             Isp_local_states.Utils

--- a/tests/general/oracle/isp_033_nested_pointers_crashes.res.oracle
+++ b/tests/general/oracle/isp_033_nested_pointers_crashes.res.oracle
@@ -19,44 +19,44 @@
   ----------------------------------------------------------------------------
 [isp] Eva analysis is completed.
 [isp] Warning: Nested pointers are not implemented!
-[kernel] Current source was: :0
+[kernel] Current source was: <unknown>
   The full backtrace is:
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Isp__Isp_local_states.Utils.process_expression.(fun) in file "src/isp_local_states.ml", line 420, characters 18-147
   Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
   Called from Isp__Isp_visitor.interface_specifications_propagator#vstmt_aux in file "src/isp_visitor.ml", line 181, characters 16-126
   Called from Frama_c_kernel__Visitor.internal_generic_frama_c_visitor#vstmt in file "src/kernel_services/visitors/visitor.ml", line 73, characters 16-35
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1295, characters 15-31
-  Called from Frama_c_kernel__Cil.visitCilStmt in file "src/kernel_services/ast_queries/cil.ml", line 2399, characters 4-103
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 779, characters 15-31
+  Called from Frama_c_kernel__Cil.visitCilStmt in file "src/kernel_services/ast_queries/cil.ml", line 1806, characters 4-103
   Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
   Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-  Called from Frama_c_kernel__Cil.mapNoCopy.aux in file "src/kernel_services/ast_queries/cil.ml", line 1334, characters 15-18
-  Called from Frama_c_kernel__Cil.childrenBlock in file "src/kernel_services/ast_queries/cil.ml", line 2582, characters 15-39
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Cil.childrenFunction in file "src/kernel_services/ast_queries/cil.ml", line 2807, characters 13-38
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Cil.visitCilFunction in file "src/kernel_services/ast_queries/cil.ml", line 2768, characters 4-89
-  Called from Frama_c_kernel__Cil.childrenGlobal in file "src/kernel_services/ast_queries/cil.ml", line 2856, characters 13-35
-  Called from Frama_c_kernel__Cil.mapNoCopy.aux in file "src/kernel_services/ast_queries/cil.ml", line 1334, characters 15-18
-  Called from Frama_c_kernel__Cil.doVisitList in file "src/kernel_services/ast_queries/cil.ml", line 1379, characters 20-53
+  Called from Frama_c_kernel__Extlib.map_no_copy.aux in file "src/libraries/stdlib/extlib.ml", line 191, characters 15-18
+  Called from Frama_c_kernel__Cil.childrenBlock in file "src/kernel_services/ast_queries/cil.ml", line 1989, characters 15-48
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Cil.childrenFunction in file "src/kernel_services/ast_queries/cil.ml", line 2215, characters 13-38
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Cil.visitCilFunction in file "src/kernel_services/ast_queries/cil.ml", line 2176, characters 4-89
+  Called from Frama_c_kernel__Cil.childrenGlobal in file "src/kernel_services/ast_queries/cil.ml", line 2264, characters 13-35
+  Called from Frama_c_kernel__Extlib.map_no_copy.aux in file "src/libraries/stdlib/extlib.ml", line 191, characters 15-18
+  Called from Frama_c_kernel__Cil.doVisitList in file "src/kernel_services/ast_queries/cil.ml", line 825, characters 20-62
   Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
   Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-  Called from Frama_c_kernel__Cil.childrenFileCopy.fGlob in file "src/kernel_services/ast_queries/cil.ml", line 5446, characters 16-36
-  Called from Frama_c_kernel__Cil.childrenFileCopy in file "src/kernel_services/ast_queries/cil.ml", line 5453, characters 2-19
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Visitor.visitFramacFileCopy in file "src/kernel_services/visitors/visitor.ml" (inlined), line 853, characters 32-68
-  Called from Frama_c_kernel__File.init_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1807, characters 12-43
-  Called from Frama_c_kernel__File.create_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1842, characters 2-43
+  Called from Frama_c_kernel__Cil.childrenFileCopy.fGlob in file "src/kernel_services/ast_queries/cil.ml", line 4540, characters 16-36
+  Called from Frama_c_kernel__Cil.childrenFileCopy in file "src/kernel_services/ast_queries/cil.ml", line 4547, characters 2-19
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Visitor.visitFramacFileCopy in file "src/kernel_services/visitors/visitor.ml" (inlined), line 851, characters 32-68
+  Called from Frama_c_kernel__File.init_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1857, characters 12-43
+  Called from Frama_c_kernel__File.create_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1892, characters 2-43
   Called from Isp__Isp_visitor.execute_isp in file "src/isp_visitor.ml", line 326, characters 4-105
   Called from Stdlib__Queue.iter.iter in file "queue.ml", line 121, characters 6-15
   Called from Frama_c_kernel__Boot.play_analysis in file "src/kernel_internals/runtime/boot.ml", line 38, characters 4-17
-  Called from Frama_c_kernel__Cmdline.play_in_toplevel_one_shot in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 837, characters 2-9
-  Called from Frama_c_kernel__Cmdline.play_in_toplevel in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 867, characters 18-64
-  Called from Frama_c_kernel__Cmdline.catch_toplevel_run in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 231, characters 4-8
+  Called from Frama_c_kernel__Cmdline.play_in_toplevel_one_shot in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 957, characters 2-9
+  Called from Frama_c_kernel__Cmdline.play_in_toplevel in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 987, characters 18-64
+  Called from Frama_c_kernel__Cmdline.catch_toplevel_run in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 238, characters 4-8
   
   Unexpected error (Failure("Isp: The pointer can only contain an expression of type lval at this point.")).
   Please report as 'crash' at https://git.frama-c.com/pub/frama-c/issues
-  Your Frama-C version is 29.0 (Copper).
+  Your Frama-C version is 31.0 (Gallium).
   Note that a version and a backtrace alone often do not contain enough
   information to understand the bug. Guidelines for reporting bugs are at:
   https://git.frama-c.com/pub/frama-c/-/wikis/Guidelines-for-reporting-bugs

--- a/tests/general/oracle/isp_034_manipulated_pointer_crashes.res.oracle
+++ b/tests/general/oracle/isp_034_manipulated_pointer_crashes.res.oracle
@@ -19,44 +19,44 @@
   ----------------------------------------------------------------------------
 [isp] Eva analysis is completed.
 [isp] Warning: Dereferencing expression (x + 1) - 1 is not implemented!
-[kernel] Current source was: :0
+[kernel] Current source was: <unknown>
   The full backtrace is:
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Isp__Isp_local_states.Utils.process_expression.(fun) in file "src/isp_local_states.ml", line 420, characters 18-147
   Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
   Called from Isp__Isp_visitor.interface_specifications_propagator#vstmt_aux in file "src/isp_visitor.ml", line 181, characters 16-126
   Called from Frama_c_kernel__Visitor.internal_generic_frama_c_visitor#vstmt in file "src/kernel_services/visitors/visitor.ml", line 73, characters 16-35
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1295, characters 15-31
-  Called from Frama_c_kernel__Cil.visitCilStmt in file "src/kernel_services/ast_queries/cil.ml", line 2399, characters 4-103
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 779, characters 15-31
+  Called from Frama_c_kernel__Cil.visitCilStmt in file "src/kernel_services/ast_queries/cil.ml", line 1806, characters 4-103
   Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
   Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-  Called from Frama_c_kernel__Cil.mapNoCopy.aux in file "src/kernel_services/ast_queries/cil.ml", line 1334, characters 15-18
-  Called from Frama_c_kernel__Cil.childrenBlock in file "src/kernel_services/ast_queries/cil.ml", line 2582, characters 15-39
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Cil.childrenFunction in file "src/kernel_services/ast_queries/cil.ml", line 2807, characters 13-38
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Cil.visitCilFunction in file "src/kernel_services/ast_queries/cil.ml", line 2768, characters 4-89
-  Called from Frama_c_kernel__Cil.childrenGlobal in file "src/kernel_services/ast_queries/cil.ml", line 2856, characters 13-35
-  Called from Frama_c_kernel__Cil.mapNoCopy.aux in file "src/kernel_services/ast_queries/cil.ml", line 1334, characters 15-18
-  Called from Frama_c_kernel__Cil.doVisitList in file "src/kernel_services/ast_queries/cil.ml", line 1379, characters 20-53
+  Called from Frama_c_kernel__Extlib.map_no_copy.aux in file "src/libraries/stdlib/extlib.ml", line 191, characters 15-18
+  Called from Frama_c_kernel__Cil.childrenBlock in file "src/kernel_services/ast_queries/cil.ml", line 1989, characters 15-48
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Cil.childrenFunction in file "src/kernel_services/ast_queries/cil.ml", line 2215, characters 13-38
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Cil.visitCilFunction in file "src/kernel_services/ast_queries/cil.ml", line 2176, characters 4-89
+  Called from Frama_c_kernel__Cil.childrenGlobal in file "src/kernel_services/ast_queries/cil.ml", line 2264, characters 13-35
+  Called from Frama_c_kernel__Extlib.map_no_copy.aux in file "src/libraries/stdlib/extlib.ml", line 191, characters 15-18
+  Called from Frama_c_kernel__Cil.doVisitList in file "src/kernel_services/ast_queries/cil.ml", line 825, characters 20-62
   Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
   Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-  Called from Frama_c_kernel__Cil.childrenFileCopy.fGlob in file "src/kernel_services/ast_queries/cil.ml", line 5446, characters 16-36
-  Called from Frama_c_kernel__Cil.childrenFileCopy in file "src/kernel_services/ast_queries/cil.ml", line 5453, characters 2-19
-  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 1310, characters 19-39
-  Called from Frama_c_kernel__Visitor.visitFramacFileCopy in file "src/kernel_services/visitors/visitor.ml" (inlined), line 853, characters 32-68
-  Called from Frama_c_kernel__File.init_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1807, characters 12-43
-  Called from Frama_c_kernel__File.create_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1842, characters 2-43
+  Called from Frama_c_kernel__Cil.childrenFileCopy.fGlob in file "src/kernel_services/ast_queries/cil.ml", line 4540, characters 16-36
+  Called from Frama_c_kernel__Cil.childrenFileCopy in file "src/kernel_services/ast_queries/cil.ml", line 4547, characters 2-19
+  Called from Frama_c_kernel__Cil.doVisit in file "src/kernel_services/ast_queries/cil.ml", line 794, characters 19-39
+  Called from Frama_c_kernel__Visitor.visitFramacFileCopy in file "src/kernel_services/visitors/visitor.ml" (inlined), line 851, characters 32-68
+  Called from Frama_c_kernel__File.init_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1857, characters 12-43
+  Called from Frama_c_kernel__File.create_project_from_visitor in file "src/kernel_services/ast_queries/file.ml", line 1892, characters 2-43
   Called from Isp__Isp_visitor.execute_isp in file "src/isp_visitor.ml", line 326, characters 4-105
   Called from Stdlib__Queue.iter.iter in file "queue.ml", line 121, characters 6-15
   Called from Frama_c_kernel__Boot.play_analysis in file "src/kernel_internals/runtime/boot.ml", line 38, characters 4-17
-  Called from Frama_c_kernel__Cmdline.play_in_toplevel_one_shot in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 837, characters 2-9
-  Called from Frama_c_kernel__Cmdline.play_in_toplevel in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 867, characters 18-64
-  Called from Frama_c_kernel__Cmdline.catch_toplevel_run in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 231, characters 4-8
+  Called from Frama_c_kernel__Cmdline.play_in_toplevel_one_shot in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 957, characters 2-9
+  Called from Frama_c_kernel__Cmdline.play_in_toplevel in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 987, characters 18-64
+  Called from Frama_c_kernel__Cmdline.catch_toplevel_run in file "src/kernel_services/cmdline_parameters/cmdline.ml", line 238, characters 4-8
   
   Unexpected error (Failure("Isp: The pointer can only contain an expression of type lval at this point.")).
   Please report as 'crash' at https://git.frama-c.com/pub/frama-c/issues
-  Your Frama-C version is 29.0 (Copper).
+  Your Frama-C version is 31.0 (Gallium).
   Note that a version and a backtrace alone often do not contain enough
   information to understand the bug. Guidelines for reporting bugs are at:
   https://git.frama-c.com/pub/frama-c/-/wikis/Guidelines-for-reporting-bugs


### PR DESCRIPTION
This PR upgrades the ISP plugin to Frama-C version 31 (Gallium).